### PR TITLE
using page[size] rather than rows for api call

### DIFF
--- a/R/dc_data_centers.R
+++ b/R/dc_data_centers.R
@@ -17,6 +17,6 @@ dc_data_centers <- function(query = NULL, member_id = NULL, offset = 0,
 
   if (!is.null(include)) include <- paste0(include, collapse = ",")
 	args <- dc_compact(list(query = query, `member-id` = member_id,
-		offset = offset, rows = rows, include = include))
+		offset = offset, `page[size]` = rows, include = include))
   dc_rest_GET("data-centers", args = args, ...)
 }

--- a/R/dc_data_centers.R
+++ b/R/dc_data_centers.R
@@ -17,6 +17,6 @@ dc_data_centers <- function(query = NULL, member_id = NULL, offset = 0,
 
   if (!is.null(include)) include <- paste0(include, collapse = ",")
 	args <- dc_compact(list(query = query, `member-id` = member_id,
-		offset = offset, `page[size]` = rows, include = include))
+	`page[offset]` = offset, `page[size]` = rows, include = include))
   dc_rest_GET("data-centers", args = args, ...)
 }

--- a/R/dc_members.R
+++ b/R/dc_members.R
@@ -17,6 +17,6 @@ dc_members <- function(query = NULL, member_type = NULL, region = NULL,
 	year = NULL,  ...) {
 
 	args <- dc_compact(list(query = query, `member-type` = member_type,
-		region = region, year = year))
+		region = region, year = year, `page[size]` = rows))
   dc_rest_GET("members", args = args, ...)
 }

--- a/R/dc_members.R
+++ b/R/dc_members.R
@@ -17,6 +17,6 @@ dc_members <- function(query = NULL, member_type = NULL, region = NULL,
 	year = NULL,  ...) {
 
 	args <- dc_compact(list(query = query, `member-type` = member_type,
-		region = region, year = year, `page[size]` = rows))
+		region = region, year = year, `page[size]` = rows, `page[offset]` = offset))
   dc_rest_GET("members", args = args, ...)
 }

--- a/R/dc_works.R
+++ b/R/dc_works.R
@@ -19,6 +19,6 @@ dc_works <- function(query = NULL, order = NULL, sort = NULL,
 
 	if (!is.null(include)) include <- paste0(include, collapse = ",")
 	args <- dc_compact(list(query = query, order = order, sort = sort,
-		rows = rows, offset = offset, include = include))
+		`page[size]` = rows, offset = offset, include = include))
   dc_rest_GET("works", args = args, ...)
 }

--- a/R/dc_works.R
+++ b/R/dc_works.R
@@ -19,6 +19,6 @@ dc_works <- function(query = NULL, order = NULL, sort = NULL,
 
 	if (!is.null(include)) include <- paste0(include, collapse = ",")
 	args <- dc_compact(list(query = query, order = order, sort = sort,
-		`page[size]` = rows, offset = offset, include = include))
+		`page[size]` = rows, `page[offset]` = offset, include = include))
   dc_rest_GET("works", args = args, ...)
 }


### PR DESCRIPTION
the DataCite REST api follows the  jsonapi spec for pagination http://jsonapi.org/format/#fetching-pagination